### PR TITLE
fix: do not change owner to admin when updating member details

### DIFF
--- a/src/utils/generics.ts
+++ b/src/utils/generics.ts
@@ -344,7 +344,11 @@ export function mapWorkspaceMembersUpdate(
 			
 			member.updatedAt = entity.updatedAtS
 			if(role === 0) { // become an admin
-				member.accessLevel = 'admin'
+				if(member.accessLevel === 'owner') { // if already an owner
+					member.accessLevel = 'owner'
+				} else {
+					member.accessLevel = 'admin'
+				}
 			} else if(role === 1) { // become a reviewer
 				member.accessLevel = 'reviewer'
 			}


### PR DESCRIPTION
When updating the details for a workspace member, if the person is already an `owner`, this PR ensures that their `accessLevel` is not changed to `admin`.