### PR TITLE
fix: logic for selected applicant count

### DIFF
--- a/src/application-mapping.ts
+++ b/src/application-mapping.ts
@@ -129,7 +129,7 @@ export function handleApplicationUpdated(event: ApplicationUpdated): void {
 	}
 
 	// increment number of applicants selected for workspace
-	if(strStateResult.value == 'completed') {
+	if(strStateResult.value == 'approved') {
 		const grant = Grant.load(entity.grant)
 		if(!grant) {
 			log.warning(`[${event.transaction.hash.toHex()}] grant (${entity.grant}) not found for application completed (${applicationId})`, [])

--- a/tests/application.test.ts
+++ b/tests/application.test.ts
@@ -85,7 +85,7 @@ export function runTests(): void {
 			new ethereum.EventParam('owner', ethereum.Value.fromAddress(Address.fromString('0xB25191F360e3847006dB660bae1c6d1b2e17eC2B'))),
 			// the IPFS hash contains mock data for the workspace
 			new ethereum.EventParam('metadataHash', ethereum.Value.fromString(UPDATE_JSON)),
-			new ethereum.EventParam('state', ethereum.Value.fromI32(0x04)), // "completed"
+			new ethereum.EventParam('state', ethereum.Value.fromI32(0x02)), // "approved"
 			new ethereum.EventParam('milestoneCount', ethereum.Value.fromI32(0x00)),
 			new ethereum.EventParam('time', ethereum.Value.fromI32(125)),
 		]
@@ -95,7 +95,7 @@ export function runTests(): void {
 
 		const gUpdate = GrantApplication.load(g!.id)
 		assert.i32Equals(gUpdate!.updatedAtS, 125)
-		assert.stringEquals(gUpdate!.state, 'completed')
+		assert.stringEquals(gUpdate!.state, 'approved')
 		assert.assertTrue(gUpdate!.version > 1)
 		// project details were updated, check value changed
 		const projectDetailsFieldUpdate = GrantFieldAnswerItem.load(`${g!.id}.projectDetails.0`)!


### PR DESCRIPTION
This PR changes the logic that calculates the number of selected applicants. Now, all applications in the `approved` state are considered.